### PR TITLE
Remove event listeners on modal close

### DIFF
--- a/lib/rxp-hpp.js
+++ b/lib/rxp-hpp.js
@@ -24,6 +24,8 @@ var RealexHpp = (function () {
 
 	var redirectUrl;
 
+	var messageEventFunctions = [];
+	
 	var internal = {
 		createFormHiddenInput: function (name, value) {
 			var el = document.createElement("input");
@@ -69,6 +71,10 @@ var RealexHpp = (function () {
 		},
 
 		closeModal: function (closeButton, iFrame, spinner, overlayElement) {
+			for(var i = 0; i < messageEventFunctions.length; i++){
+                window.removeEventListener("message", messageEventFunctions[i]);
+			}
+			
 			if (closeButton && closeButton.parentNode) {
 				closeButton.parentNode.removeChild(closeButton);
 			}
@@ -430,10 +436,12 @@ var RealexHpp = (function () {
 					document.getElementById(idOfLightboxButton).attachEvent('onclick', lightboxInstance.lightbox);
 				}
 
+				var messageEventFunction = internal.receiveMessage(lightboxInstance, merchantUrl);
 				if (window.addEventListener) {
-					window.addEventListener("message", internal.receiveMessage(lightboxInstance, merchantUrl), false);
+					messageEventFunctions.push(messageEventFunction);
+				    window.addEventListener("message", messageEventFunction, false);
 				} else {
-					window.attachEvent('message', internal.receiveMessage(lightboxInstance, merchantUrl));
+				    window.attachEvent('message', messageEventFunction);
 				}
 			}
 		};
@@ -504,10 +512,12 @@ var RealexHpp = (function () {
 					document.getElementById(idOfEmbeddedButton).attachEvent('onclick', embeddedInstance.embedded);
 				}
 
+				var messageEventFunction = internal.receiveMessage(embeddedInstance, merchantUrl, true);
 				if (window.addEventListener) {
-					window.addEventListener("message", internal.receiveMessage(embeddedInstance, merchantUrl, true), false);
+					messageEventFunctions.push(messageEventFunction);
+				    window.addEventListener("message", messageEventFunction, false);
 				} else {
-					window.attachEvent('message', internal.receiveMessage(embeddedInstance, merchantUrl, true));
+				    window.attachEvent('message', messageEventFunction);
 				}
 			}
 		};
@@ -568,10 +578,12 @@ var RealexHpp = (function () {
 					document.getElementById(idOfButton).attachEvent('onclick', redirectInstance.redirect);
 				}
 
+				var messageEventFunction = internal.receiveMessage(redirectInstance, merchantUrl);
 				if (window.addEventListener) {
-					window.addEventListener("message", internal.receiveMessage(redirectInstance, merchantUrl), false);
+					messageEventFunctions.push(messageEventFunction);
+					window.addEventListener("message", messageEventFunction, false);
 				} else {
-					window.attachEvent('message', internal.receiveMessage(redirectInstance, merchantUrl));
+				    window.attachEvent('message', messageEventFunction);
 				}
 			}
 		};


### PR DESCRIPTION
Remove event listeners from window on close modal, to prevent calling multiple times merchantUrl, if user close modal and reopen it.